### PR TITLE
Add TWZRD Agent Intel — on-chain wallet trust scoring for agent identity

### DIFF
--- a/ai-agent-infra-list.md
+++ b/ai-agent-infra-list.md
@@ -433,6 +433,16 @@ AgentConnect provides agent authentication methods based on the W3C DID specific
 GitHub repository: [https://github.com/chgaowei/AgentConnect](https://github.com/chgaowei/AgentConnect)
 
 
+
+
+### TWZRD Agent Intel
+
+TWZRD Agent Intel is an MCP server for on-chain trust scoring and reputation verification of AI agent wallets on Solana. Before autonomous agents make x402 micropayments to unknown wallets, they can call `score_agent(wallet)` to get a trust score (0-100) and `preflight_check(wallet)` for a go/no-go signal. Signed trust receipts are available via `get_trust_receipt(wallet)`.
+
+Homepage: [https://intel.twzrd.xyz](https://intel.twzrd.xyz)
+
+MCP configuration: `{"mcpServers": {"twzrd-agent-intel": {"url": "https://intel.twzrd.xyz/mcp"}}}`
+
 ## Runtime
 
 


### PR DESCRIPTION
Add [TWZRD Agent Intel](https://intel.twzrd.xyz) to the **Authentication** section under Tools.

TWZRD Agent Intel is an MCP server that provides on-chain trust scoring and reputation verification for AI agent wallets on Solana. It fills the "who am I talking to?" gap when autonomous agents need to transact with unknown wallets via x402 micropayments.

**Tools:**
- `score_agent(wallet)` — free reputation score (0-100) from on-chain history
- `preflight_check(wallet)` — free go/no-go signal with risk flags
- `get_trust_receipt(wallet)` — signed trust receipt (x402 micropayment)

**Config:** `{"mcpServers": {"twzrd-agent-intel": {"url": "https://intel.twzrd.xyz/mcp"}}}`

Homepage: https://intel.twzrd.xyz
